### PR TITLE
feat(server): add server side channel checking

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -96,7 +96,7 @@ RegisterNUICallback('joinRadio', function(data, cb)
             if rchannel ~= RadioChannel then
                 if rchannel <= Config.RestrictedChannels then
                     local xPlayer = QBCore.Functions.GetPlayerData()
-                    if (xPlayer.job.name == 'police' or xPlayer.job.name == 'ambulance') and xPlayer.job.onduty then
+                    if Config.AllowedJobs[xPlayer.job.name] and xPlayer.job.onduty then
                         connecttoradio(rchannel)
                     else
                         QBCore.Functions.Notify(Config.messages['restricted_channel_error'], 'error')

--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,12 @@ Config.RestrictedChannels = 10 -- channels that are encrypted (EMS, Fire and pol
 
 Config.MaxFrequency = 500
 
+-- jobs that are allowed to be on Restricted channels
+Config.AllowedJobs = {
+  ['police'] = true,
+  ['ambulance'] = true
+}
+
 Config.messages = {
   ['not_on_radio'] = 'Your not connected to a signal',
   ['on_radio'] = 'Your already connected to this signal',

--- a/server.lua
+++ b/server.lua
@@ -17,3 +17,13 @@ QBCore.Functions.CreateCallback('qb-radio:server:GetItem', function(source, cb, 
         cb(false)
     end
 end)
+
+for i = 1, Config.RestrictedChannels do 
+    exports['pma-voice']:addChannelCheck(i, function(source)
+        local Player = QBCore.Functions.GetPlayer(source)
+        if Config.AllowedJobs[Player.PlayerData.job.name] and Player.PlayerData.job.onduty then
+            return true
+        end
+        return false
+    end)
+end


### PR DESCRIPTION
I don't have any way to test the code provided, though none of this should break any compatibility.

This also requires the use of version [5 or greater](https://github.com/AvarianKnight/pma-voice/releases/tag/v5.0.0-beta)