### PR TITLE
feat(config): make single channels restricted by jobs

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -96,7 +96,7 @@ RegisterNUICallback('joinRadio', function(data, cb)
             if rchannel ~= RadioChannel then
                 if Config.RestrictedChannels[rchannel] ~= nil then
                     local xPlayer = QBCore.Functions.GetPlayerData()
-                    if Config.RestrictedChannels[xPlayer.job.name] and xPlayer.job.onduty then
+                    if Config.RestrictedChannels[rchannel][xPlayer.job.name] and xPlayer.job.onduty then
                         connecttoradio(rchannel)
                     else
                         QBCore.Functions.Notify(Config.messages['restricted_channel_error'], 'error')

--- a/client.lua
+++ b/client.lua
@@ -94,9 +94,9 @@ RegisterNUICallback('joinRadio', function(data, cb)
     if rchannel ~= nil then
         if rchannel <= Config.MaxFrequency and rchannel ~= 0 then
             if rchannel ~= RadioChannel then
-                if rchannel <= Config.RestrictedChannels then
+                if Config.RestrictedChannels[rchannel] ~= nil then
                     local xPlayer = QBCore.Functions.GetPlayerData()
-                    if Config.AllowedJobs[xPlayer.job.name] and xPlayer.job.onduty then
+                    if Config.RestrictedChannels[xPlayer.job.name] and xPlayer.job.onduty then
                         connecttoradio(rchannel)
                     else
                         QBCore.Functions.Notify(Config.messages['restricted_channel_error'], 'error')

--- a/config.lua
+++ b/config.lua
@@ -1,14 +1,19 @@
 Config = {}
 
-Config.RestrictedChannels = 10 -- channels that are encrypted (EMS, Fire and police can be included there) if we give eg 10, channels from 1 - 10 will be encrypted
+Config.RestrictedChannels = {
+  [482] = {
+    police = true
+  },
+  [470] = {
+    ambulance = true
+  },
+  [858] = {
+    police = true,
+    ambulance = true
+  }
+} 
 
 Config.MaxFrequency = 500
-
--- jobs that are allowed to be on Restricted channels
-Config.AllowedJobs = {
-  ['police'] = true,
-  ['ambulance'] = true
-}
 
 Config.messages = {
   ['not_on_radio'] = 'Your not connected to a signal',

--- a/server.lua
+++ b/server.lua
@@ -18,12 +18,9 @@ QBCore.Functions.CreateCallback('qb-radio:server:GetItem', function(source, cb, 
     end
 end)
 
-for i = 1, Config.RestrictedChannels do 
-    exports['pma-voice']:addChannelCheck(i, function(source)
+for channel, config in pairs(Config.RestrictedChannels) do
+    exports['pma-voice']:addChannelCheck(channel, function(source)
         local Player = QBCore.Functions.GetPlayer(source)
-        if Config.AllowedJobs[Player.PlayerData.job.name] and Player.PlayerData.job.onduty then
-            return true
-        end
-        return false
+        return config[Player.PlayerData.job.name] and Player.PlayerData.job.onduty
     end)
 end


### PR DESCRIPTION
If applied, this PR changes the channel restrictions. New restrictions can be created and applied to multiple jobs.

```lua
Config.RestrictedChannels = {
  --
  -- Syntax Reference
  --
  [targetChannel] = {
    playerJob = true,
    playerJob = true,
  },

  --
  -- Examples
  --

  -- Make a channel accessible only for police
  [482] = { -- channel 482
    police = true
  },
  -- Make a channel accessible for police and ambulance
  [456] = {
    police = true,
    ambulance = true
  }
}
  ```