### PR TITLE
fix deps order when start server on fxdk

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -23,4 +23,6 @@ files {
   'html/img/radio.png'
 }
 
+dependency 'pma-voice'
+
 lua54 'yes'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Radio'
-version '1.2.1'
+version '1.2.2'
 
 shared_script 'config.lua'
 


### PR DESCRIPTION
**Describe Pull request**
This PR is fix when run server in fxdk because it can't managing start order of it

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
