### PR TITLE
Remove lines from fxmanifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,6 @@ shared_script 'config.lua'
 
 client_scripts {
   'client.lua',
-  'animation.lua'
 }
 
 server_script 'server.lua'
@@ -19,7 +18,6 @@ files {
   'html/ui.html',
   'html/js/script.js',
   'html/css/style.css',
-  'html/img/cursor.png',
   'html/img/radio.png'
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Radio'
-version '1.2.0'
+version '1.2.1'
 
 shared_script 'config.lua'
 


### PR DESCRIPTION
**Describe Pull request**
A member of the community discord had mentioned an issue that they had with qb-radio. Seen below:

![image](https://user-images.githubusercontent.com/122633389/223424242-5cd1dd8e-c083-4bba-a7e2-964f97503222.png)

Seems like things were deleted and never removed from the fxmanifest. This PR fixes the warnings shown above.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
