### PR TITLE
Avoid double execution of slideDown on closure

### DIFF
--- a/html/js/script.js
+++ b/html/js/script.js
@@ -12,7 +12,6 @@ $(function() {
     document.onkeyup = function (data) {
         if (data.which == 27) { // Escape key
             $.post('https://qb-radio/escape', JSON.stringify({}));
-            QBRadio.SlideDown()
         } else if (data.which == 13) { // Enter key
             $.post('https://qb-radio/joinRadio', JSON.stringify({
                 channel: $("#channel").val()


### PR DESCRIPTION
**Describe Pull request**
When closing the radio via the escape key an event is being triggered on the "backend" (client.lua) script which then closes the radio. This close function already sends an event back to the frontend to execute the frontend slide down function. So it is not required to execute it again.

(See https://github.com/qbcore-framework/qb-radio/blob/main/client.lua#L85 and https://github.com/qbcore-framework/qb-radio/blob/main/html/js/script.js#L8)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
