### PR TITLE
Radio QOL and bug fixes

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -211,6 +211,7 @@ RegisterNUICallback("volumeDown", function(_, cb)
 end)
 
 RegisterNUICallback("increaseradiochannel", function(_, cb)
+    if not onRadio then return end
     local newChannel = RadioChannel + 1
     local canaccess = connecttoradio(newChannel)
     cb({

--- a/client.lua
+++ b/client.lua
@@ -164,6 +164,7 @@ RegisterNUICallback('joinRadio', function(data, cb)
                     canaccess = canaccess,
                     channel = RadioChannel
                 })
+                return
             else
                 QBCore.Functions.Notify(Lang:t('you_on_radio') , 'error')
             end
@@ -177,6 +178,7 @@ RegisterNUICallback('joinRadio', function(data, cb)
         canaccess = false,
         channel = RadioChannel
     })
+    return
 end)
 
 RegisterNUICallback('leaveRadio', function(_, cb)

--- a/client.lua
+++ b/client.lua
@@ -225,7 +225,7 @@ end)
 RegisterNUICallback("decreaseradiochannel", function(_, cb)
     if not onRadio then return end
     local newChannel = RadioChannel - 1
-    if newChannel >= 1 then
+    if newChannel > 0 then
         local canaccess = connecttoradio(newChannel)
         cb({
             canaccess = canaccess,

--- a/client.lua
+++ b/client.lua
@@ -230,13 +230,11 @@ end)
 RegisterNUICallback("decreaseradiochannel", function(_, cb)
     if not onRadio then return end
     local newChannel = round(tonumber(RadioChannel - 1), 2)
-    if newChannel > 0 then
-        local canaccess = connecttoradio(newChannel)
-        cb({
-            canaccess = canaccess,
-            channel = newChannel
-        })
-    end
+    local canaccess = connecttoradio(newChannel)
+    cb({
+        canaccess = canaccess,
+        channel = newChannel
+    })
 end)
 
 RegisterNUICallback('poweredOff', function(_, cb)

--- a/client.lua
+++ b/client.lua
@@ -28,6 +28,11 @@ local function SplitStr(inputstr, sep)
     return t
 end
 
+function round(number, decimalPlaces)
+    local multiple = 10^(decimalPlaces or 0)
+    return math.floor(number * multiple + 0.5) / multiple
+  end
+
 local function connecttoradio(channel)
     if channel > Config.MaxFrequency or channel <= 0 then QBCore.Functions.Notify(Lang:t('restricted_channel_error'), 'error') return false end
     if Config.RestrictedChannels[channel] ~= nil then
@@ -155,7 +160,7 @@ end)
 
 -- NUI
 RegisterNUICallback('joinRadio', function(data, cb)
-    local rchannel = tonumber(data.channel)
+    local rchannel = round(tonumber(data.channel), 2)
     if rchannel ~= nil then
         if rchannel <= Config.MaxFrequency and rchannel > 0 then
             if rchannel ~= RadioChannel then
@@ -214,7 +219,7 @@ end)
 
 RegisterNUICallback("increaseradiochannel", function(_, cb)
     if not onRadio then return end
-    local newChannel = RadioChannel + 1
+    local newChannel = round(tonumber(RadioChannel + 1), 2)
     local canaccess = connecttoradio(newChannel)
     cb({
        canaccess = canaccess,
@@ -224,7 +229,7 @@ end)
 
 RegisterNUICallback("decreaseradiochannel", function(_, cb)
     if not onRadio then return end
-    local newChannel = RadioChannel - 1
+    local newChannel = round(tonumber(RadioChannel - 1), 2)
     if newChannel > 0 then
         local canaccess = connecttoradio(newChannel)
         cb({


### PR DESCRIPTION
This PR brings multiple QOL and bug fixes.

1. Added channel decimal rounding to two digits. It's odd that people can currently enter 499.9999999999 for channel numbers for example.  This also fixes a strange use case when using the radio increase/decrease buttons that would also cause the channel to round oddly. The screenshots below was when I manually navigated to 16.1, then spammed the radio channel increase button multiple times, then spammed the radio channel decrease button to get below 15.1 to start seeing the issue.
2. Fixed an inconsistency between being able to manually navigate to 0.1, but being unable to manually navigate to 1.1 and then clicking the channel down arrow.
3. Fixed an issue where canaccess was being overwritten in `joinRadio`.
4. Added a missing condition between the radio increase/decrease buttons.

![Screenshot 2024-11-12 234441](https://github.com/user-attachments/assets/2cbbf85f-072e-4c4d-ab4b-751885583d72)
![Screenshot 2024-11-12 161316](https://github.com/user-attachments/assets/7c987d81-014f-4f89-a6c5-d3726d51eda7)


bug fixes related to integer rounding issues when using the 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes