### PR TITLE
Add es.lua locale and removed unsused phrase

### DIFF
--- a/locales/de.lua
+++ b/locales/de.lua
@@ -1,6 +1,5 @@
 local Translations ={
     ["not_on_radio"] = "Du bist nicht mit einem Signal verbunden",
-    ["on_radio"] = "Du bist bereits mit diesem Signal verbunden",
     ["joined_to_radio"] = "Du bist verbunden mit: %{channel}",
     ["restricted_channel_error"] = "Du kannst dich nicht mit diesem Signal verbinden!",
     ["invalid_radio"] = "Diese Frequenz ist nicht verfügbar.",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,6 +1,5 @@
 local Translations ={
     ["not_on_radio"] = "You're not connected to a signal",
-    ["on_radio"] = "You're already connected to this signal",
     ["joined_to_radio"] = "You're connected to: %{channel}",
     ["restricted_channel_error"] = "You can not connect to this signal!",
     ["invalid_radio"] = "This frequency is not available.",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,0 +1,19 @@
+local Translations = {
+    ["not_on_radio"] = "No estás conectado a ninguna frecuencia",
+    ["joined_to_radio"] = "Te has conectado a: %{channel}",
+    ["restricted_channel_error"] = "¡No te puedes conectar a esta frecuencia!",
+    ["invalid_radio"] = "Esta frecuencia no está disponible.",
+    ["you_on_radio"] = "Ya estás conectado a esta frecuencia",
+    ["you_leave"] = "Has abandonado la frecuencia.",
+    ['volume_radio'] = 'Nuevo volumen %{value}',
+    ['decrease_radio_volume'] = 'La radio ya está al máximo volumen',
+    ['increase_radio_volume'] = 'La radio ya está al mínimo volumen',
+}
+
+if GetConvar('qb_locale', 'en') == 'es' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/pt-br.lua
+++ b/locales/pt-br.lua
@@ -1,6 +1,5 @@
 local Translations = {
     ["not_on_radio"] = "Você não está conectado a um sinal",
-    ["on_radio"] = "Você já está conectado a este sinal",
     ["joined_to_radio"] = "Você está conectado a: %{channel}",
     ["restricted_channel_error"] = "Você não pode se conectar a este sinal!",
     ["invalid_radio"] = "Esta frequência não está disponível.",


### PR DESCRIPTION
**Describe Pull request**
This PR brings the Spanish locale to the radio script. Also removes the unused locale `on_radio` which I couldn't find any use of it.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Put they are just locale it shouldn't be any problem at all)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
